### PR TITLE
CI: remove forked `nix-update` dependency

### DIFF
--- a/.github/workflows/update-all.yml
+++ b/.github/workflows/update-all.yml
@@ -58,9 +58,7 @@ jobs:
 
       - uses: yaxitech/nix-install-pkgs-action@v7
         with:
-          # There's a fun little happenstance where upstream tries fetching from an invalid url
-          # packages: "github:Mic92/nix-update, nixpkgs#jq"
-          packages: "github:ProverbialPennance/nix-update"
+          packages: "github:Mic92/nix-update, nixpkgs#jq"
 
       - name: Configure git
         run: |


### PR DESCRIPTION
It would appear that the issues I encountered related to invalid request URLs should be fixed, at least from a quick perusing of the PR.