### PR TITLE
Do not persist credentials in flake.yml

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -15,6 +15,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: DeterminateSystems/nix-installer-action@v20
         with:


### PR DESCRIPTION
Until upstream pulls in newer dependencies that fixes issues with checkout@v6 this becomes necessary to ensure the workflow does not fail.