### PR TITLE
remove persist credentials

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -15,8 +15,6 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
 
       - uses: DeterminateSystems/nix-installer-action@v20
         with:


### PR DESCRIPTION
With the new version of the flake action, this should no longer be necessary.