### PR TITLE
Start a partial maintanance of packages and modules from the discontinued chaotic-nix flake

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -20,6 +20,8 @@ final: prev: {
   r2modman = final.callPackage ./pkgs/r2modman {};
   generic-updater = final.callPackage ./scripts/update/generic-updater.nix {};
 
+  gamescope-git = final.callPackage ./pkgs/gamescope-git {};
+
   # sm64baserom = final.callPackage ./pkgs/sm64baserom {};
   # sm64ex-ap = final.callPackage ./pkgs/sm64ex-ap {sm64baserom = final.callPackage ./pkgs/sm64baserom {};};
 }

--- a/pkgs/gamescope-git/default.nix
+++ b/pkgs/gamescope-git/default.nix
@@ -8,7 +8,7 @@
   fetchFromGitHub,
   gamescope,
 }: let
-  rev' = "9416ca9334da7ff707359e5f6aa65dcfff66aa01";
+  rev' = "70614184ebf6d12dd1e390082d98ad569e7601aa";
   shortRev = builtins.substring 0 7 rev';
 in
   gamescope.overrideAttrs (prevAttrs: {
@@ -18,7 +18,7 @@ in
       owner = "ValveSoftware";
       repo = "gamescope";
       rev = "${rev'}";
-      sha256 = "sha256-bZXyNmhLG1ZcD9nNKG/BElp6I57GAwMSqAELu2IZnqA=";
+      sha256 = "sha256-StmXf8G3SIacddFxg5xMyvHI2ESiaWaivw3ZM9jAQM4=";
       fetchSubmodules = true;
     };
 

--- a/pkgs/gamescope-git/default.nix
+++ b/pkgs/gamescope-git/default.nix
@@ -1,3 +1,7 @@
+# MIT License
+#
+# Copyright (c) 2023 Pedro Henrique Lara Campos <nyx@pedrohlc.com>
+#
 {
   lib,
   generic-updater,

--- a/pkgs/gamescope-git/default.nix
+++ b/pkgs/gamescope-git/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  generic-updater,
+  fetchFromGitHub,
+  gamescope,
+}: let
+  rev' = "9416ca9334da7ff707359e5f6aa65dcfff66aa01";
+  shortRev = builtins.substring 0 7 rev';
+in
+  gamescope.overrideAttrs (prevAttrs: {
+    pname = "gamescope-git";
+    version = "3.16.14.5" + "+${shortRev}";
+    src = fetchFromGitHub {
+      owner = "ValveSoftware";
+      repo = "gamescope";
+      rev = "${rev'}";
+      sha256 = "sha256-bZXyNmhLG1ZcD9nNKG/BElp6I57GAwMSqAELu2IZnqA=";
+      fetchSubmodules = true;
+    };
+
+    passthru.updateScript = generic-updater {
+      extraArgs = [
+        "--version=branch"
+      ];
+    };
+
+    postPatch =
+      prevAttrs.postPatch
+      + ''
+        substituteInPlace layer/VkLayer_FROG_gamescope_wsi.cpp \
+          --replace-fail 'WSI] Surface' 'WSI ${shortRev}] Surface'
+        substituteInPlace src/meson.build \
+          --replace-fail "'git', 'describe', '--always', '--tags', '--dirty=+'" "'echo', '${prevAttrs.src.rev}'"
+
+        patchShebangs default_extras_install.sh
+      '';
+  })


### PR DESCRIPTION
Primarily looking at:

- [x] `gamescope-git`
- [ ] `mesa-git` & `mesa32-git`
- - [ ] `librm-git` & `libdrm32-git`
- - [x] `wayland-protocols-git`
- - - [x] `wayland-scanner-git`
- - - [x] `wayland-git`
- [ ] `linux-cachyos`

EDIT `2025-12-09T18:41+01:00`:
`mesa-git` also brings in a fair few dependencies.