### PR TITLE
[PKGS] build with debug information & impl module options

### DIFF
--- a/modules/_2ship2harkinian-git.nix
+++ b/modules/_2ship2harkinian-git.nix
@@ -22,9 +22,20 @@ in {
         _2ship2harkinian-git package to use.
       '';
     };
+    buildWithDebug = mkOption {
+      type = types.bool;
+      default = true;
+      description = lib.mdDoc ''
+        Whether to build as a `RelWithDebInfo` binary or `MinSizeRel`.
+        **N.B** incompatible with other packages than those provided by JOMR.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [cfg.package];
+    environment.systemPackages =
+      if cfg.buildWithDebug
+      then [cfg.package.override {withDebug = cfg.buildWithDebug;}]
+      else [cfg.package];
   };
 }

--- a/modules/ghostship.nix
+++ b/modules/ghostship.nix
@@ -22,9 +22,20 @@ in {
         ghostship package to use.
       '';
     };
+    buildWithDebug = mkOption {
+      type = types.bool;
+      default = true;
+      description = lib.mdDoc ''
+        Whether to build as a `RelWithDebInfo` binary or `MinSizeRel`.
+        **N.B** incompatible with other packages than those provided by JOMR.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [cfg.package];
+    environment.systemPackages =
+      if cfg.buildWithDebug
+      then [cfg.package.override {withDebug = cfg.buildWithDebug;}]
+      else [cfg.package];
   };
 }

--- a/modules/shipwright-git.nix
+++ b/modules/shipwright-git.nix
@@ -22,9 +22,20 @@ in {
         shipwright-git package to use.
       '';
     };
+    buildWithDebug = mkOption {
+      type = types.bool;
+      default = true;
+      description = lib.mdDoc ''
+        Whether to build as a `RelWithDebInfo` binary or `MinSizeRel`.
+        **N.B** incompatible with other packages than those provided by JOMR.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [cfg.package];
+    environment.systemPackages =
+      if cfg.buildWithDebug
+      then [cfg.package.override {withDebug = cfg.buildWithDebug;}]
+      else [cfg.package];
   };
 }

--- a/modules/spaghetti-kart-git.nix
+++ b/modules/spaghetti-kart-git.nix
@@ -22,9 +22,20 @@ in {
         spaghetti-kart-git package to use.
       '';
     };
+    buildWithDebug = mkOption {
+      type = types.bool;
+      default = true;
+      description = lib.mdDoc ''
+        Whether to build as a `RelWithDebInfo` binary or `MinSizeRel`.
+        **N.B** incompatible with other packages than those provided by JOMR.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [cfg.package];
+    environment.systemPackages =
+      if cfg.buildWithDebug
+      then [cfg.package.override {withDebug = cfg.buildWithDebug;}]
+      else [cfg.package];
   };
 }

--- a/modules/starship-sf64.nix
+++ b/modules/starship-sf64.nix
@@ -22,9 +22,20 @@ in {
         starship-sf64 package to use.
       '';
     };
+    buildWithDebug = mkOption {
+      type = types.bool;
+      default = true;
+      description = lib.mdDoc ''
+        Whether to build as a `RelWithDebInfo` binary or `MinSizeRel`.
+        **N.B** incompatible with other packages than those provided by JOMR.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [cfg.package];
+    environment.systemPackages =
+      if cfg.buildWithDebug
+      then [cfg.package.override {withDebug = cfg.buildWithDebug;}]
+      else [cfg.package];
   };
 }

--- a/pkgs/_2ship2harkinian-git/default.nix
+++ b/pkgs/_2ship2harkinian-git/default.nix
@@ -30,6 +30,7 @@
   tinyxml-2,
   zenity,
   makeDesktopItem,
+  withDebug ? true,
 }: let
   # The following are either normally fetched during build time or a specific version is required
   gamecontrollerdb = fetchFromGitHub {
@@ -108,6 +109,11 @@ in
     passthru.updateScript = generic-updater {
       extraArgs = ["--version=branch"];
     };
+
+    cmakeBuildType =
+      if withDebug
+      then "RelWithDebInfo"
+      else "MinSizeRel";
 
     patches = [
       # remove fetching stb as we will patch our own

--- a/pkgs/ghostship/default.nix
+++ b/pkgs/ghostship/default.nix
@@ -28,6 +28,7 @@
   zenity,
   ghostship,
   makeDesktopItem,
+  withDebug ? true,
 }: let
   # The following are either normally fetched during build time or a specific version is required
   dr_libs = fetchFromGitHub {
@@ -117,6 +118,11 @@ in
     };
 
     passthru.updateScript = generic-updater {};
+
+    cmakeBuildType =
+      if withDebug
+      then "RelWithDebInfo"
+      else "MinSizeRel";
 
     patches = [
       # Don't fetch stb as we will patch our own

--- a/pkgs/shipwright-ap/default.nix
+++ b/pkgs/shipwright-ap/default.nix
@@ -40,6 +40,7 @@
   sdl_gamecontrollerdb,
   shipwright-ap,
   generic-updater,
+  withDebug ? true,
 }: let
   # The following would normally get fetched at build time, or a specific version is required
   imgui' = applyPatches {
@@ -139,6 +140,11 @@ in
         "--version=branch=Harkipellago"
       ];
     };
+
+    cmakeBuildType =
+      if withDebug
+      then "RelWithDebInfo"
+      else "MinSizeRel";
 
     patches = [
       ./darwin-fixes.patch

--- a/pkgs/shipwright-git/default.nix
+++ b/pkgs/shipwright-git/default.nix
@@ -37,6 +37,7 @@
   bzip2,
   libx11,
   sdl_gamecontrollerdb,
+  withDebug ? true,
 }: let
   # The following would normally get fetched at build time, or a specific version is required
   dr_libs = fetchFromGitHub {
@@ -136,6 +137,11 @@ in
         "--version=branch=develop"
       ];
     };
+
+    cmakeBuildType =
+      if withDebug
+      then "RelWithDebInfo"
+      else "MinSizeRel";
 
     patches = [
       ./darwin-fixes.patch

--- a/pkgs/spaghetti-kart-git/default.nix
+++ b/pkgs/spaghetti-kart-git/default.nix
@@ -31,6 +31,7 @@
   spaghetti-kart-git,
   makeDesktopItem,
   generic-updater,
+  withDebug ? true,
 }: let
   # The following are either normally fetched during build time or a specific version is required
   dr_libs = fetchFromGitHub {
@@ -142,6 +143,11 @@ in
         "--version=branch"
       ];
     };
+
+    cmakeBuildType =
+      if withDebug
+      then "RelWithDebInfo"
+      else "MinSizeRel";
 
     patches = [
       # Don't fetch stb as we will patch our own

--- a/pkgs/starship-sf64/default.nix
+++ b/pkgs/starship-sf64/default.nix
@@ -27,6 +27,7 @@
   zenity,
   starship-sf64,
   makeDesktopItem,
+  withDebug ? true,
 }: let
   # The following are either normally fetched during build time or a specific version is required
   dr_libs = fetchFromGitHub {
@@ -115,6 +116,11 @@ in
     };
 
     passthru.updateScript = generic-updater {};
+
+    cmakeBuildType =
+      if withDebug
+      then "RelWithDebInfo"
+      else "MinSizeRel";
 
     patches = [
       # Don't fetch stb as we will patch our own


### PR DESCRIPTION
I am ambivalent towards the default option being to enable or disable the
`withDebug` option, however I do think that for the purposes of cachix and such,
I would rather the inclusion of the debug information be the default.

This does however make the "simple" implementation of the module options not *really*,
work as a real way to disable the `withDebug` option.

- **add withDebug build option, default `true`**
- **provide module options for `withDebug` option in relevant packages**

closes #1021  

[![Build](https://github.com/ProverbialPennance/just-one-more-repo/actions/workflows/build.yml/badge.svg?branch=pkgs%2Fbuild-with-debug-info)](https://github.com/ProverbialPennance/just-one-more-repo/actions/workflows/build.yml)