### PR TITLE
[MODULES] fix incorrect `.override` syntax 

### DIFF
--- a/modules/_2ship2harkinian-git.nix
+++ b/modules/_2ship2harkinian-git.nix
@@ -35,7 +35,7 @@ in {
   config = mkIf cfg.enable {
     environment.systemPackages =
       if cfg.buildWithDebug
-      then [cfg.package.override {withDebug = cfg.buildWithDebug;}]
+      then [(cfg.package.override {withDebug = cfg.buildWithDebug;})]
       else [cfg.package];
   };
 }

--- a/modules/ghostship.nix
+++ b/modules/ghostship.nix
@@ -35,7 +35,7 @@ in {
   config = mkIf cfg.enable {
     environment.systemPackages =
       if cfg.buildWithDebug
-      then [cfg.package.override {withDebug = cfg.buildWithDebug;}]
+      then [(cfg.package.override {withDebug = cfg.buildWithDebug;})]
       else [cfg.package];
   };
 }

--- a/modules/shipwright-git.nix
+++ b/modules/shipwright-git.nix
@@ -35,7 +35,7 @@ in {
   config = mkIf cfg.enable {
     environment.systemPackages =
       if cfg.buildWithDebug
-      then [cfg.package.override {withDebug = cfg.buildWithDebug;}]
+      then [(cfg.package.override {withDebug = cfg.buildWithDebug;})]
       else [cfg.package];
   };
 }

--- a/modules/spaghetti-kart-git.nix
+++ b/modules/spaghetti-kart-git.nix
@@ -35,7 +35,7 @@ in {
   config = mkIf cfg.enable {
     environment.systemPackages =
       if cfg.buildWithDebug
-      then [cfg.package.override {withDebug = cfg.buildWithDebug;}]
+      then [(cfg.package.override {withDebug = cfg.buildWithDebug;})]
       else [cfg.package];
   };
 }

--- a/modules/starship-sf64.nix
+++ b/modules/starship-sf64.nix
@@ -35,7 +35,7 @@ in {
   config = mkIf cfg.enable {
     environment.systemPackages =
       if cfg.buildWithDebug
-      then [cfg.package.override {withDebug = cfg.buildWithDebug;}]
+      then [(cfg.package.override {withDebug = cfg.buildWithDebug;})]
       else [cfg.package];
   };
 }


### PR DESCRIPTION
- **attempt to bring back build logs**
- **wrap override in parens to eval into a derivation**
