### PR TITLE
[PKGS] don't strip symbols when `withDebug` is supplied

### DIFF
--- a/pkgs/_2ship2harkinian-git/default.nix
+++ b/pkgs/_2ship2harkinian-git/default.nix
@@ -181,6 +181,8 @@ in
     # Linking fails without this
     hardeningDisable = ["format"];
 
+    dontStrip = withDebug;
+
     preConfigure = ''
       # mirror 2ship's stb
       mkdir stb

--- a/pkgs/ghostship/default.nix
+++ b/pkgs/ghostship/default.nix
@@ -195,6 +195,8 @@ in
 
     # dontAddPrefix = true;
 
+    dontStrip = withDebug;
+
     # Linking fails without this
     hardeningDisable = ["format"];
 

--- a/pkgs/shipwright-ap/default.nix
+++ b/pkgs/shipwright-ap/default.nix
@@ -250,6 +250,8 @@ in
 
     dontAddPrefix = true;
 
+    dontStrip = withDebug;
+
     # Linking fails without this
     hardeningDisable = ["format"];
 

--- a/pkgs/shipwright-git/default.nix
+++ b/pkgs/shipwright-git/default.nix
@@ -215,6 +215,8 @@ in
 
     dontAddPrefix = true;
 
+    dontStrip = withDebug;
+
     # Linking fails without this
     hardeningDisable = ["format"];
 

--- a/pkgs/spaghetti-kart-git/default.nix
+++ b/pkgs/spaghetti-kart-git/default.nix
@@ -222,6 +222,8 @@ in
 
     strictDeps = true;
 
+    dontStrip = withDebug;
+
     # Linking fails without this
     hardeningDisable = ["format"];
 

--- a/pkgs/starship-sf64/default.nix
+++ b/pkgs/starship-sf64/default.nix
@@ -194,6 +194,8 @@ in
 
     strictDeps = true;
 
+    dontStrip = withDebug;
+
     # Linking fails without this
     hardeningDisable = ["format"];
 


### PR DESCRIPTION
Forgot to set the flag in the previous pr (#1022) to disable nix's stripping
of the binaries.
