### PR TITLE
replace `passthru.updateScript` with `unstableGitUpdater`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,4 +2,5 @@
   # This is needed for  the nix-build invocation done by nix-update
   xivlauncher-rb = pkgs.callPackage ./pkgs/xivlauncher-rb {};
   r2modman = pkgs.callPackage ./pkgs/r2modman {};
+  perfect-dark-git = pkgs.callPackage ./pkgs/perfect-dark-git {};
 }

--- a/pkgs/perfect-dark-git/default.nix
+++ b/pkgs/perfect-dark-git/default.nix
@@ -1,6 +1,6 @@
 {
   romID ? "ntsc-final",
-  generic-updater,
+  unstableGitUpdater,
   lib,
   fetchFromGitHub,
   stdenv,
@@ -31,9 +31,7 @@ in
         hash = "sha256-WRLimMwlimBbEQtdcIHaDIy7Vg+PcM/H6sYSSDd4oFo=";
       };
 
-      passthru.updateScript = generic-updater {
-        extraArgs = ["--version=branch"];
-      };
+      passthru.updateScript = unstableGitUpdater {hardcodeZeroVersion = true;};
 
       buildInputs = [
         libGL


### PR DESCRIPTION
add `perfect-dark-git` attr to `default.nix` so that the script can pick up the needed
information, as well as locate the real path of the derivation.

this should fix the failing updates in ci.
