### PR TITLE
[pkgs] init `shipwright-ap-stable` @ Client_1.2.x

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -22,6 +22,7 @@ final: prev: {
   generic-updater = final.callPackage ./scripts/update/generic-updater.nix {};
 
   shipwright-ap = final.callPackage ./pkgs/shipwright-ap {};
+  shipwright-ap-stable = final.callPackage ./pkgs/shipwright-ap-stable {};
   ghostship = final.callPackage ./pkgs/ghostship {};
   # sm64baserom = final.callPackage ./pkgs/sm64baserom {};
   # sm64ex-ap = final.callPackage ./pkgs/sm64ex-ap {sm64baserom = final.callPackage ./pkgs/sm64baserom {};};

--- a/pkgs/shipwright-ap-stable/darwin-fixes.patch
+++ b/pkgs/shipwright-ap-stable/darwin-fixes.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2771ee8c..0702adad 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -250,17 +250,13 @@ endif()
+ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+ add_custom_target(CreateOSXIcons
+     COMMAND mkdir -p ${CMAKE_BINARY_DIR}/macosx/soh.iconset
+-    COMMAND sips -z 16 16     ${CMAKE_SOURCE_DIR}/soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_16x16.png
+-    COMMAND sips -z 32 32     ${CMAKE_SOURCE_DIR}/soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_16x16@2x.png
+-    COMMAND sips -z 32 32     ${CMAKE_SOURCE_DIR}/soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_32x32.png
+-    COMMAND sips -z 64 64     ${CMAKE_SOURCE_DIR}/soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_32x32@2x.png
+-    COMMAND sips -z 128 128   ${CMAKE_SOURCE_DIR}/soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_128x128.png
+-    COMMAND sips -z 256 256   ${CMAKE_SOURCE_DIR}/soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_128x128@2x.png
+-    COMMAND sips -z 256 256   ${CMAKE_SOURCE_DIR}/soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_256x256.png
+-    COMMAND sips -z 512 512   ${CMAKE_SOURCE_DIR}/soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_256x256@2x.png
+-    COMMAND sips -z 512 512   ${CMAKE_SOURCE_DIR}/soh/macosx/sohIcon.png --out ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_512x512.png
+-    COMMAND cp                ${CMAKE_SOURCE_DIR}/soh/macosx/sohIcon.png ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_512x512@2x.png
+-    COMMAND iconutil -c icns -o ${CMAKE_BINARY_DIR}/macosx/soh.icns ${CMAKE_BINARY_DIR}/macosx/soh.iconset
++    COMMAND convert ${CMAKE_SOURCE_DIR}/soh/macosx/sohIcon.png -resize 16x16 ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_16.png
++    COMMAND convert ${CMAKE_SOURCE_DIR}/soh/macosx/sohIcon.png -resize 32x32 ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_32.png
++    COMMAND convert ${CMAKE_SOURCE_DIR}/soh/macosx/sohIcon.png -resize 64x64 ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_64.png
++    COMMAND convert ${CMAKE_SOURCE_DIR}/soh/macosx/sohIcon.png -resize 128x128 ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_128.png
++    COMMAND convert ${CMAKE_SOURCE_DIR}/soh/macosx/sohIcon.png -resize 256x256 ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_256.png
++    COMMAND convert ${CMAKE_SOURCE_DIR}/soh/macosx/sohIcon.png -resize 512x512 ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_512.png
++    COMMAND png2icns ${CMAKE_BINARY_DIR}/macosx/soh.icns ${CMAKE_BINARY_DIR}/macosx/soh.iconset/icon_{16,32,64,128,256,512}.png
+     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+     COMMENT "Creating OSX icons ..."
+     )
+@@ -288,7 +284,6 @@ INSTALL(CODE "FILE(RENAME \${CMAKE_INSTALL_PREFIX}/../MacOS/soh-macos \${CMAKE_I
+
+ install(CODE "
+     include(BundleUtilities)
+-    fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/../MacOS/soh\" \"\" \"${dirs}\")
+     ")
+
+ endif()

--- a/pkgs/shipwright-ap-stable/default.nix
+++ b/pkgs/shipwright-ap-stable/default.nix
@@ -1,0 +1,361 @@
+{
+  apple-sdk_13,
+  stdenv,
+  replaceVars,
+  cmake,
+  lsb-release,
+  ninja,
+  lib,
+  fetchFromGitHub,
+  fetchurl,
+  copyDesktopItems,
+  makeDesktopItem,
+  python3,
+  glew,
+  cacert,
+  SDL2,
+  SDL2_net,
+  pkg-config,
+  libpulseaudio,
+  libpng,
+  imagemagick,
+  zenity,
+  makeWrapper,
+  darwin,
+  libicns,
+  libvorbis,
+  libogg,
+  libopus,
+  opusfile,
+  openssl,
+  libzip,
+  nlohmann_json,
+  valijson,
+  websocketpp,
+  tinyxml-2,
+  spdlog,
+  writeTextFile,
+  fixDarwinDylibNames,
+  applyPatches,
+  sdl_gamecontrollerdb,
+  shipwright-ap-stable,
+  # generic-updater,
+  writeScript,
+  withDebug ? true,
+}: let
+  # The following would normally get fetched at build time, or a specific version is required
+  imgui' = applyPatches {
+    src = fetchFromGitHub {
+      owner = "ocornut";
+      repo = "imgui";
+      tag = "v1.91.9-docking";
+      hash = "sha256-4L37NRR+dlkhdxuDjhLR45kgjyZK2uelKBlGZ1nQzgY=";
+    };
+    patches = [
+      "${shipwright-ap-stable.src}/libultraship/cmake/dependencies/patches/imgui-fixes-and-config.patch"
+    ];
+  };
+
+  libgfxd = fetchFromGitHub {
+    owner = "glankk";
+    repo = "libgfxd";
+    rev = "008f73dca8ebc9151b205959b17773a19c5bd0da";
+    hash = "sha256-AmHAa3/cQdh7KAMFOtz5TQpcM6FqO9SppmDpKPTjTt8=";
+  };
+
+  prism = fetchFromGitHub {
+    owner = "KiritoDv";
+    repo = "prism-processor";
+    rev = "bbcbc7e3f890a5806b579361e7aa0336acd547e7";
+    hash = "sha256-jRPwO1Vub0cH12YMlME6kd8zGzKmcfIrIJZYpQJeOks=";
+  };
+
+  stb_impl = writeTextFile {
+    name = "stb_impl.c";
+    text = ''
+      #define STB_IMAGE_IMPLEMENTATION
+      #include "stb_image.h"
+    '';
+  };
+
+  stb' = fetchurl {
+    name = "stb_image.h";
+    url = "https://raw.githubusercontent.com/nothings/stb/0bc88af4de5fb022db643c2d8e549a0927749354/stb_image.h";
+    hash = "sha256-xUsVponmofMsdeLsI6+kQuPg436JS3PBl00IZ5sg3Vw=";
+  };
+
+  stormlib' = applyPatches {
+    src = fetchFromGitHub {
+      owner = "ladislav-zezula";
+      repo = "StormLib";
+      tag = "v9.25";
+      hash = "sha256-HTi2FKzKCbRaP13XERUmHkJgw8IfKaRJvsK3+YxFFdc=";
+    };
+    patches = [
+      "${shipwright-ap-stable.src}/libultraship/cmake/dependencies/patches/stormlib-optimizations.patch"
+    ];
+  };
+
+  thread_pool = fetchFromGitHub {
+    owner = "bshoshany";
+    repo = "thread-pool";
+    tag = "v4.1.0";
+    hash = "sha256-zhRFEmPYNFLqQCfvdAaG5VBNle9Qm8FepIIIrT9sh88=";
+  };
+
+  metalcpp = fetchFromGitHub {
+    owner = "briaguya-ai";
+    repo = "single-header-metal-cpp";
+    tag = "macOS13_iOS16";
+    hash = "sha256-CSYIpmq478bla2xoPL/cGYKIWAeiORxyFFZr0+ixd7I";
+  };
+
+  openssl' = openssl.override {static = true;};
+
+  tag' = "Client_1.2.x";
+in
+  stdenv.mkDerivation (finalAttrs: {
+    pname = "shipwright-ap-stable";
+    version = "Client_1.2.x";
+
+    src = fetchFromGitHub {
+      #currently only on jeromkiller's fork
+      owner = "jeromkiller";
+      repo = "Shipwright_archipellago";
+      tag = "${tag'}";
+      hash = "sha256-4r2xHgjb89ENWZLoZ9QkZaJOGkUSMi7fZlyp5ASGxrY=";
+      # hash = lib.fakeHash;
+      fetchSubmodules = true;
+      deepClone = true;
+      postFetch = ''
+        cd $out
+        git branch --show-current > GIT_BRANCH
+        git rev-parse --short=7 HEAD > GIT_COMMIT_HASH
+        (git describe --tags --abbrev=0 --exact-match HEAD 2>/dev/null || echo "") > GIT_COMMIT_TAG
+        rm -rf .git
+      '';
+    };
+
+    passthru.updateScrip = writeScript "update-shipwright-ap-stable" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p nix-update
+      nix-update ${finalAttrs.pname} --flake --version-regex '([clientCLIENT]+_\d\.\d\.(?:\d|[xX]))' --version=unstable
+    '';
+
+    # passthru.updateScript = generic-updater {
+    #   extraArgs = [
+    #     "--version=branch=Harkipellago"
+    #   ];
+    # };
+
+    cmakeBuildType =
+      if withDebug
+      then "RelWithDebInfo"
+      else "MinSizeRel";
+
+    patches = [
+      ./darwin-fixes.patch
+      ./disable-downloading-stb_image.patch
+      (replaceVars ./dont-fetch-deps.patch {
+        dr_libs_src = fetchFromGitHub {
+          owner = "mackron";
+          repo = "dr_libs";
+          rev = "da35f9d6c7374a95353fd1df1d394d44ab66cf01";
+          hash = "sha256-ydFhQ8LTYDBnRTuETtfWwIHZpRciWfqGsZC6SuViEn0=";
+        };
+        cacert_src = cacert;
+        asio_src = fetchFromGitHub {
+          owner = "chriskohlhoff";
+          repo = "asio";
+          tag = "asio-1-30-2";
+          hash = "sha256-g+ZPKBUhBGlgvce8uTkuR983unD2kbQKgoddko7x+fk=";
+        };
+        wswrap_src = fetchFromGitHub {
+          owner = "black-sliver";
+          repo = "wswrap";
+          rev = "47438193ec50427ee28aadf294ba57baefd9f3f1";
+          hash = "sha256-WWXi/OWfaC40V+tV4JNmVM8kImozuwaiRLeSdhIf0X8=";
+        };
+        apclientpp_src = fetchFromGitHub {
+          owner = "black-sliver";
+          repo = "apclientpp";
+          rev = "65638b7479f6894eda172e603cffa79762c0ddc1";
+          hash = "sha256-/pUa51tZmFL15moMO1KlX5iBmMcx/vYMhqO6PZckIPo=";
+        };
+      })
+    ];
+
+    nativeBuildInputs =
+      [
+        cmake
+        ninja
+        pkg-config
+        python3
+        imagemagick
+        makeWrapper
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
+        lsb-release
+        copyDesktopItems
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        libicns
+        darwin.sigtool
+        fixDarwinDylibNames
+      ];
+
+    buildInputs =
+      [
+        # boost
+        glew
+        SDL2
+        SDL2_net
+        libpng
+        libzip
+        nlohmann_json
+        valijson
+        websocketpp
+        tinyxml-2
+        spdlog
+        libvorbis
+        libogg
+        libopus
+        opusfile
+
+        openssl'
+        openssl'.dev
+        cacert
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
+        libpulseaudio
+        zenity
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        # Metal.hpp requires macOS 13.x min.
+        apple-sdk_13
+      ];
+
+    cmakeFlags =
+      [
+        (lib.cmakeBool "BUILD_REMOTE_CONTROL" true)
+        (lib.cmakeBool "NON_PORTABLE" true)
+        (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "${placeholder "out"}/lib")
+        (lib.cmakeFeature "OPUSFILE_INCLUDE_DIR" "${opusfile.dev}")
+        (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_IMGUI" "${imgui'}")
+        (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_LIBGFXD" "${libgfxd}")
+        (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_PRISM" "${prism}")
+        (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_STORMLIB" "${stormlib'}")
+        (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_THREADPOOL" "${thread_pool}")
+        (lib.cmakeBool "APCLIENTPP_BUILD_TESTING" false)
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_METALCPP" "${metalcpp}")
+        (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_SPDLOG" "${spdlog}")
+      ];
+
+    env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-Wno-int-conversion -Wno-implicit-int -Wno-elaborated-enum-base";
+
+    dontAddPrefix = true;
+
+    dontStrip = withDebug;
+
+    # Linking fails without this
+    hardeningDisable = ["format"];
+
+    preConfigure = ''
+      mkdir stb
+      cp ${stb'} ./stb/${stb'.name}
+      cp ${stb_impl} ./stb/${stb_impl.name}
+      substituteInPlace libultraship/cmake/dependencies/common.cmake \
+        --replace-fail "\''${STB_DIR}" "$(readlink -f ./stb)"
+    '';
+
+    postPatch = ''
+      substituteInPlace soh/src/boot/build.c.in \
+      --replace-fail "@CMAKE_PROJECT_GIT_BRANCH@" "$(cat GIT_BRANCH)" \
+      --replace-fail "@CMAKE_PROJECT_GIT_COMMIT_HASH@" "$(cat GIT_COMMIT_HASH)" \
+      --replace-fail "@CMAKE_PROJECT_GIT_COMMIT_TAG@" "$(cat GIT_COMMIT_TAG)"
+    '';
+
+    postBuild = ''
+      port_ver=$(grep CMAKE_PROJECT_VERSION: "$PWD/CMakeCache.txt" | cut -d= -f2)
+      cp ${sdl_gamecontrollerdb}/share/gamecontrollerdb.txt gamecontrollerdb.txt
+      echo $(ls)
+      mkdir -p soh/networking
+      cp ${cacert}/etc/ssl/certs/ca-no-trust-rules-bundle.crt soh/networking/cacert.pem
+      mv ../libultraship/src/fast/shaders ../soh/assets/custom
+      pushd ../OTRExporter
+      python3 ./extract_assets.py -z ../build/ZAPD/ZAPD.out --norom --xml-root ../soh/assets/xml --custom-assets-path ../soh/assets/custom --custom-otr-file soh.o2r --port-ver $port_ver
+      popd
+    '';
+
+    preInstall = ''
+      # Cmake likes it here for its install paths
+      cp ../OTRExporter/soh.o2r soh/soh.o2r
+    '';
+
+    postInstall =
+      lib.optionalString stdenv.hostPlatform.isLinux ''
+        mkdir -p $out/bin
+        ln -s $out/lib/soh.elf $out/bin/soh-ap-stable
+        install -Dm644 ../soh/macosx/sohIcon.png $out/share/pixmaps/soh.png
+      ''
+      + lib.optionalString stdenv.hostPlatform.isDarwin ''
+        # Recreate the macOS bundle (without using cpack)
+        # We mirror the structure of the bundle distributed by the project
+
+        mkdir -p $out/Applications/soh.app/Contents
+        cp $src/soh/macosx/Info.plist.in $out/Applications/soh.app/Contents/Info.plist
+        substituteInPlace $out/Applications/soh.app/Contents/Info.plist \
+          --replace-fail "@CMAKE_PROJECT_VERSION@" "${finalAttrs.version}"
+
+        mv $out/MacOS $out/Applications/soh.app/Contents/MacOS
+
+        # "lib" contains all resources that are in "Resources" in the official bundle.
+        # We move them to the right place and symlink them back to $out/lib,
+        # as that's where the game expects them.
+        mv $out/Resources $out/Applications/soh.app/Contents/Resources
+        mv $out/lib/** $out/Applications/soh.app/Contents/Resources
+        rm -rf $out/lib
+        ln -s $out/Applications/soh.app/Contents/Resources $out/lib
+
+        # Copy icons
+        cp -r ../build/macosx/soh.icns $out/Applications/soh.app/Contents/Resources/soh.icns
+
+        # Codesign (ad-hoc)
+        codesign -f -s - $out/Applications/soh.app/Contents/MacOS/soh
+      '';
+
+    fixupPhase = lib.optionalString stdenv.hostPlatform.isLinux ''
+      wrapProgram $out/lib/soh.elf --prefix PATH ":" ${lib.makeBinPath [zenity]}
+    '';
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = "soh-ap-stable";
+        icon = "soh";
+        exec = "soh-ap-stable";
+        comment = finalAttrs.meta.description;
+        genericName = "Ship of Harkinian (AP [stable])";
+        desktopName = "soh-ap-stable";
+        categories = ["Game"];
+      })
+    ];
+
+    meta = {
+      homepage = "https://github.com/HarbourMasters/Shipwright";
+      description = "PC port of Ocarina of Time with modern controls, widescreen, high-resolution, and more";
+      mainProgram = "soh-ap-stable";
+      platforms = lib.platforms.linux ++ lib.platforms.darwin;
+      # maintainers = with lib.maintainers; [
+      #   j0lol
+      #   matteopacini
+      # ];
+      license = with lib.licenses; [
+        # OTRExporter, OTRGui, ZAPDTR, libultraship
+        mit
+        # Ship of Harkinian itself
+        unfree
+      ];
+    };
+  })

--- a/pkgs/shipwright-ap-stable/disable-downloading-stb_image.patch
+++ b/pkgs/shipwright-ap-stable/disable-downloading-stb_image.patch
@@ -1,0 +1,16 @@
+Submodule libultraship contains modified content
+diff --git a/libultraship/cmake/dependencies/common.cmake b/libultraship/cmake/dependencies/common.cmake
+index 596158c..c62d7b2 100644
+--- a/libultraship/cmake/dependencies/common.cmake
++++ b/libultraship/cmake/dependencies/common.cmake
+@@ -47,10 +47,6 @@ set(stormlib_optimizations_patch git apply ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dep
+ endif()
+
+ #=================== STB ===================
+-set(STB_DIR ${CMAKE_BINARY_DIR}/_deps/stb)
+-file(DOWNLOAD "https://github.com/nothings/stb/raw/0bc88af4de5fb022db643c2d8e549a0927749354/stb_image.h" "${STB_DIR}/stb_image.h")
+-file(WRITE "${STB_DIR}/stb_impl.c" "#define STB_IMAGE_IMPLEMENTATION\n#include \"stb_image.h\"")
+-
+ add_library(stb STATIC)
+
+ target_sources(stb PRIVATE

--- a/pkgs/shipwright-ap-stable/dont-fetch-deps.patch
+++ b/pkgs/shipwright-ap-stable/dont-fetch-deps.patch
@@ -1,0 +1,72 @@
+diff --git a/soh/CMakeLists.txt b/soh/CMakeLists.txt
+index aa979f6ed..52014d0f9 100644
+--- a/soh/CMakeLists.txt
++++ b/soh/CMakeLists.txt
+@@ -306,8 +306,7 @@ if(BUILD_REMOTE_CONTROL)
+ 
+     FetchContent_Declare(
+             asio
+-            GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
+-            GIT_TAG asio-1-30-2
++            URL @asio_src@
+     )
+     FetchContent_MakeAvailable(asio)
+     target_include_directories(${PROJECT_NAME} PRIVATE ${asio_SOURCE_DIR}/asio/include)
+@@ -328,16 +326,14 @@ if(BUILD_REMOTE_CONTROL)
+ 
+     FetchContent_Declare(
+             wswrap
+-            GIT_REPOSITORY https://github.com/black-sliver/wswrap.git
+-            GIT_TAG 47438193ec50427ee28aadf294ba57baefd9f3f1
++            URL @wswrap_src@
+     )
+     FetchContent_MakeAvailable(wswrap)
+     target_include_directories(${PROJECT_NAME} PRIVATE ${wswrap_SOURCE_DIR}/include)
+ 
+     FetchContent_Declare(
+             apclientpp
+-            GIT_REPOSITORY https://github.com/black-sliver/apclientpp.git
+-            GIT_TAG 65638b7479f6894eda172e603cffa79762c0ddc1
++            URL @apclientpp_src@
+     )
+     FetchContent_MakeAvailable(apclientpp)
+     target_include_directories(${PROJECT_NAME} PRIVATE ${apclientpp_SOURCE_DIR})
+@@ -347,8 +343,7 @@ endif()
+ ################################################################################
+ FetchContent_Declare(
+         dr_libs
+-        GIT_REPOSITORY https://github.com/mackron/dr_libs.git
+-        GIT_TAG da35f9d6c7374a95353fd1df1d394d44ab66cf01
++        URL @dr_libs_src@
+ )
+ FetchContent_MakeAvailable(dr_libs)
+ 
+@@ -372,11 +367,13 @@ if (BUILD_REMOTE_CONTROL)
+     set(OPENSSL_USE_STATIC_LIBS ON)
+ 
+     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+-        file(STRINGS /etc/os-release distro REGEX "^NAME=")
+-        string(REGEX REPLACE "NAME=\"(.*)\"" "\\1" distro "${distro}")
++        if(EXISTS /etc/os-release)
++            file(STRINGS /etc/os-release distro REGEX "^NAME=")
++            string(REGEX REPLACE "NAME=\"(.*)\"" "\\1" distro "${distro}")
+ 
+-        if(${distro} MATCHES "Fedora Linux")
+-            set(OPENSSL_USE_STATIC_LIBS OFF)
++            if(${distro} MATCHES "Fedora Linux")
++                set(OPENSSL_USE_STATIC_LIBS OFF)
++            endif()
+         endif()
+     endif()
+ 
+@@ -389,9 +386,7 @@ if (BUILD_REMOTE_CONTROL)
+ 
+     FetchContent_Declare(
+         sslCertStore
+-        URL https://curl.se/ca/cacert.pem
+-        DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR}/networking
+-        DOWNLOAD_NO_EXTRACT TRUE
++        URL @cacert_src@
+     )
+ 
+     FetchContent_MakeAvailable(


### PR DESCRIPTION
This should ensure that players always have access
to the correct version of the client for the
latest released AP world
