### PR TITLE
[CI] do not include runtime closures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           # build (main branch)
           set -euxo pipefail
-          om ci run .#packages --include-all-dependencies --results=om.json -- --show-trace
+          om ci run .#packages --results=om.json -- --show-trace
 
           declare -A derivationArray=()
 
@@ -73,4 +73,4 @@ jobs:
         run: |
           # build ("${{ env.BRANCH_NAME }}" branch)
           set -euxo pipefail
-          om ci run .#packages --include-all-dependencies -- --show-trace | xargs cachix push -j 2 -l 9 just-one-more-cache
+          om ci run .#packages -- --show-trace | xargs cachix push -j 2 -l 9 just-one-more-cache


### PR DESCRIPTION
while we still rely primarily on cachix, don't include runtime closures to try and reduce closure size. Currently we keep running into issues pinning where sometimes the final closure sizes varies slightly between builds.
