### PR TITLE
`sm64coopdx` - cleanup and small improvements

### DIFF
--- a/pkgs/sm64coopdx/default.nix
+++ b/pkgs/sm64coopdx/default.nix
@@ -29,7 +29,9 @@ stdenv.mkDerivation (finalAtrrs: {
     hash = "sha256-wTT4pMTcX7w0dwxK9YjiptA71vYk+5uL6gBJaPkAGYI=";
   };
 
-  passthru.updateScript = generic-updater {};
+  passthru.updateScript = generic-updater {
+    extraArgs = ["--commit"];
+  };
 
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/sm64coopdx/default.nix
+++ b/pkgs/sm64coopdx/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAtrrs: {
     owner = "coop-deluxe";
     repo = "sm64coopdx";
     tag = "v${finalAtrrs.version}";
-    hash = "sha256-wTT4pMTcX7w0dwxK9YjiptA71vYk+5uL6gBJaPkAGYI=";
+    hash = "sha256-xSKdwkk73pcpSy4HY3P30yV1SRf7pbEVJCK6IlK19Y8=";
   };
 
   passthru.updateScript = generic-updater {

--- a/pkgs/sm64coopdx/default.nix
+++ b/pkgs/sm64coopdx/default.nix
@@ -27,8 +27,6 @@ stdenv.mkDerivation (finalAtrrs: {
     repo = "sm64coopdx";
     tag = "v${finalAtrrs.version}";
     hash = "sha256-wTT4pMTcX7w0dwxK9YjiptA71vYk+5uL6gBJaPkAGYI=";
-    deepClone = true;
-    leaveDotGit = true;
   };
 
   passthru.updateScript = generic-updater {};


### PR DESCRIPTION
- **don't include .git in src checkout**
- **un-attended commit during update-script**
- **sm64coopdx: 1.5 -> 1.5**
