### PR TITLE
pkgs: `scopebuddy` add awk dependency to wrapper

### DIFF
--- a/pkgs/scopebuddy/default.nix
+++ b/pkgs/scopebuddy/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   generic-updater,
-  awk,
+  gawk,
   perl,
   jq,
   stdenvNoCC,
@@ -34,8 +34,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   fixupPhase = ''
-    wrapProgram $out/bin/scopebuddy --prefix PATH : ${lib.makeBinPath [perl jq awk]}
-    wrapProgram $out/bin/scb --prefix PATH : ${lib.makeBinPath [perl jq awk]}
+    wrapProgram $out/bin/scopebuddy --prefix PATH : ${lib.makeBinPath [perl jq gawk]}
+    wrapProgram $out/bin/scb --prefix PATH : ${lib.makeBinPath [perl jq gawk]}
   '';
 
   meta = with lib; {

--- a/pkgs/scopebuddy/default.nix
+++ b/pkgs/scopebuddy/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   generic-updater,
+  awk,
   perl,
   jq,
   stdenvNoCC,
@@ -33,8 +34,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   fixupPhase = ''
-    wrapProgram $out/bin/scopebuddy --prefix PATH : ${lib.makeBinPath [perl jq]}
-    wrapProgram $out/bin/scb --prefix PATH : ${lib.makeBinPath [perl jq]}
+    wrapProgram $out/bin/scopebuddy --prefix PATH : ${lib.makeBinPath [perl jq awk]}
+    wrapProgram $out/bin/scb --prefix PATH : ${lib.makeBinPath [perl jq awk]}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Add awk to the `makeWrapper`. Version 1.5.0 added a function that depends on `awk` to set the `GAMEDIR` variable in user scripts.
